### PR TITLE
new: add policy ecc-azure-225-asb_reslogs_search

### DIFF
--- a/policies/ecc-azure-225-asb_reslogs_search.yml
+++ b/policies/ecc-azure-225-asb_reslogs_search.yml
@@ -9,12 +9,17 @@ policies:
   - name: ecc-azure-225-asb_reslogs_search
     comment: '020019010000'
     description: |
-      Azure Search with logging and retention policy disabled
+      Azure Search with logging disabled
     resource: azure.search
     filters:
       - or:
+        - type: diagnostic-settings
+          key: logs
+          value: absent
+        - not:
           - type: diagnostic-settings
-            enabled: false
-          - type: diagnostic-settings
-            key: length(logs[?category == 'OperationLogs' && enabled == `true` && retention_policy.enabled == `true` && retention_policy.days > `0`])
-            value: 0
+            key: logs[?category == 'OperationLogs'][].enabled
+            value: true
+            op: in
+            value_type: swap
+            

--- a/terraform/ecc-azure-225-asb_reslogs_search/green/diagnostic_settings.tf
+++ b/terraform/ecc-azure-225-asb_reslogs_search/green/diagnostic_settings.tf
@@ -11,13 +11,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
   target_resource_id = azurerm_search_service.this.id
   storage_account_id = azurerm_storage_account.this.id
 
-  log {
+  enabled_log {
     category = "OperationLogs"
-    enabled  = true
-
-    retention_policy {
-      enabled = true
-      days    = 180
-    }
   }
 }


### PR DESCRIPTION
Retention policy was removed from diagnostic setting of resource. Now we should enable Lifecycle management on Storage account - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/migrate-to-azure-storage-lifecycle-policy?tabs=portal.
Terraform - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting#retention_policy