### PR TITLE
new: add policy ecc-azure-036-cis_log_storage_cont_access

### DIFF
--- a/policies/ecc-azure-036-cis_log_storage_cont_access.yml
+++ b/policies/ecc-azure-036-cis_log_storage_cont_access.yml
@@ -11,6 +11,9 @@ policies:
       Storage container that stores activity logs where public access level set to "Blob" or "Container"
     resource: azure.storage-container
     filters:
+      - type: value
+        key: name
+        value: insights-operational-logs
       - or:
           - type: value
             key: properties.publicAccess
@@ -18,4 +21,3 @@ policies:
           - type: value
             key: properties.publicAccess
             value: Container
-      - storage-single-log-profile


### PR DESCRIPTION
The container in SA creates automatically with name "insights-operational-logs" an cannot be changed by some one.
https://stackoverflow.com/questions/12370656/how-to-rename-the-container-name-in-windows-azure