### PR TITLE
deprecate policies 020, 021, 022, 023

### DIFF
--- a/policies/ecc-azure-020-cis_db_sql_va.yml
+++ b/policies/ecc-azure-020-cis_db_sql_va.yml
@@ -1,0 +1,16 @@
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+policies:
+  - name: ecc-azure-020-cis_db_sql_va
+    comment: '020016061500'
+    description: |
+      Azure SQL Vulnerability Assesment is disabled or storage account property is not configured
+    resource: azure.sql-server
+    filters:
+      - type: vulnerability-assessment
+        key: storageContainerPath
+        value: absent

--- a/policies/ecc-azure-021-cis_db_sql_va_periodic_scan.yml
+++ b/policies/ecc-azure-021-cis_db_sql_va_periodic_scan.yml
@@ -1,0 +1,16 @@
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+policies:
+  - name: ecc-azure-021-cis_db_sql_va_periodic_scan
+    comment: '020016061500'
+    description: |
+      Azure SQL Vulnerability Assesment Reccuring Scans is disabled
+    resource: azure.sql-server
+    filters:
+      - type: vulnerability-assessment
+        key: recurringScans.isEnabled
+        value: false

--- a/policies/ecc-azure-022-cis_db_sql_va_send_scan_report.yml
+++ b/policies/ecc-azure-022-cis_db_sql_va_send_scan_report.yml
@@ -1,0 +1,16 @@
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+policies:
+  - name: ecc-azure-022-cis_db_sql_va_send_scan_report
+    comment: '020016061500'
+    description: |
+      Azure SQL Vulnerability Assesment setting 'Send scan reports to' is not configured
+    resource: azure.sql-server
+    filters:
+      - type: vulnerability-assessment
+        key: recurringScans.emails
+        value: empty

--- a/policies/ecc-azure-023-cis_db_sql_va_email_notifications.yml
+++ b/policies/ecc-azure-023-cis_db_sql_va_email_notifications.yml
@@ -1,0 +1,16 @@
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+policies:
+  - name: ecc-azure-023-cis_db_sql_va_email_notifications
+    comment: '020016061500'
+    description: |
+      Azure SQL Vulnerability Assesment emailing to admins and subscription owners is not configured
+    resource: azure.sql-server
+    filters:
+      - type: vulnerability-assessment
+        key: recurringScans.emailSubscriptionAdmins
+        value: false

--- a/terraform/ecc-azure-020-cis_db_sql_va/green/provider.tf
+++ b/terraform/ecc-azure-020-cis_db_sql_va/green/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform/ecc-azure-020-cis_db_sql_va/green/random.tf
+++ b/terraform/ecc-azure-020-cis_db_sql_va/green/random.tf
@@ -1,0 +1,11 @@
+resource "random_password" "this" {
+  length  = 13
+  special = true
+  number  = false
+}
+
+resource "random_string" "this" {
+  length  = 8
+  number  = false
+  special = false
+}

--- a/terraform/ecc-azure-020-cis_db_sql_va/green/resource_group.tf
+++ b/terraform/ecc-azure-020-cis_db_sql_va/green/resource_group.tf
@@ -1,0 +1,4 @@
+resource "azurerm_resource_group" "this" {
+  name     = "${var.prefix}-rg-green"
+  location = var.location
+}

--- a/terraform/ecc-azure-020-cis_db_sql_va/green/sql_server.tf
+++ b/terraform/ecc-azure-020-cis_db_sql_va/green/sql_server.tf
@@ -1,0 +1,21 @@
+resource "azurerm_mssql_server" "this" {
+  name                         = "${var.prefix}azuresqlserver-green"
+  resource_group_name          = azurerm_resource_group.this.name
+  location                     = azurerm_resource_group.this.location
+  version                      = "12.0"
+  administrator_login          = random_string.this.result
+  administrator_login_password = random_password.this.result
+  tags                         = var.tags
+}
+
+resource "azurerm_mssql_server_security_alert_policy" "this" {
+  resource_group_name = azurerm_resource_group.this.name
+  server_name         = azurerm_mssql_server.this.name
+  state               = "Enabled"
+}
+
+resource "azurerm_mssql_server_vulnerability_assessment" "this" {
+  server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.this.id
+  storage_container_path          = "${azurerm_storage_account.this.primary_blob_endpoint}${azurerm_storage_container.this.name}/"
+  storage_account_access_key      = azurerm_storage_account.this.primary_access_key
+}

--- a/terraform/ecc-azure-020-cis_db_sql_va/green/storage_account.tf
+++ b/terraform/ecc-azure-020-cis_db_sql_va/green/storage_account.tf
@@ -1,0 +1,15 @@
+resource "azurerm_storage_account" "this" {
+  name                     = "${var.prefix}sagreen"
+  resource_group_name      = azurerm_resource_group.this.name
+  location                 = azurerm_resource_group.this.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  tags                     = var.tags
+}
+
+resource "azurerm_storage_container" "this" {
+  name                  = "${var.prefix}scgreen"
+  storage_account_name  = azurerm_storage_account.this.name
+  container_access_type = "private"
+  depends_on            = [azurerm_mssql_server.this]
+}

--- a/terraform/ecc-azure-020-cis_db_sql_va/green/terraform.tfvars
+++ b/terraform/ecc-azure-020-cis_db_sql_va/green/terraform.tfvars
@@ -1,0 +1,8 @@
+prefix = "020"
+
+location = "eastus"
+
+tags = {
+  CustodianRule    = "ecc-azure-020-cis_db_sql_va"
+  ComplianceStatus = "Green"
+}

--- a/terraform/ecc-azure-020-cis_db_sql_va/green/variables.tf
+++ b/terraform/ecc-azure-020-cis_db_sql_va/green/variables.tf
@@ -1,0 +1,11 @@
+variable "prefix" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/terraform/ecc-azure-020-cis_db_sql_va/iam/ecc-azure-020-cis_db_sql_va.json
+++ b/terraform/ecc-azure-020-cis_db_sql_va/iam/ecc-azure-020-cis_db_sql_va.json
@@ -1,0 +1,20 @@
+{
+    "properties": {
+        "roleName": "Custodian-ecc-azure-020-cis_db_sql_va",
+        "description": "",
+        "assignableScopes": [
+            "/subscriptions/{subscription_id}"
+        ],
+        "permissions": [
+            {
+                "actions": [
+                    "Microsoft.Sql/servers/read",
+                    "Microsoft.Sql/servers/vulnerabilityAssessments/read"
+                ],
+                "notActions": [],
+                "dataActions": [],
+                "notDataActions": []
+            }
+        ]
+    }
+}

--- a/terraform/ecc-azure-020-cis_db_sql_va/red/provider.tf
+++ b/terraform/ecc-azure-020-cis_db_sql_va/red/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform/ecc-azure-020-cis_db_sql_va/red/random.tf
+++ b/terraform/ecc-azure-020-cis_db_sql_va/red/random.tf
@@ -1,0 +1,11 @@
+resource "random_password" "this" {
+  length  = 13
+  special = true
+  number  = false
+}
+
+resource "random_string" "this" {
+  length  = 8
+  number  = false
+  special = false
+}

--- a/terraform/ecc-azure-020-cis_db_sql_va/red/resource_group.tf
+++ b/terraform/ecc-azure-020-cis_db_sql_va/red/resource_group.tf
@@ -1,0 +1,4 @@
+resource "azurerm_resource_group" "this" {
+  name     = "${var.prefix}-rg-red"
+  location = var.location
+}

--- a/terraform/ecc-azure-020-cis_db_sql_va/red/sql_server.tf
+++ b/terraform/ecc-azure-020-cis_db_sql_va/red/sql_server.tf
@@ -1,0 +1,9 @@
+resource "azurerm_mssql_server" "this" {
+  name                         = "${var.prefix}azuresqlserver-red"
+  resource_group_name          = azurerm_resource_group.this.name
+  location                     = azurerm_resource_group.this.location
+  version                      = "12.0"
+  administrator_login          = random_string.this.result
+  administrator_login_password = random_password.this.result
+  tags                         = var.tags
+}

--- a/terraform/ecc-azure-020-cis_db_sql_va/red/terraform.tfvars
+++ b/terraform/ecc-azure-020-cis_db_sql_va/red/terraform.tfvars
@@ -1,0 +1,8 @@
+prefix = "020"
+
+location = "eastus"
+
+tags = {
+  CustodianRule    = "ecc-azure-020-cis_db_sql_va"
+  ComplianceStatus = "Red"
+}

--- a/terraform/ecc-azure-020-cis_db_sql_va/red/variables.tf
+++ b/terraform/ecc-azure-020-cis_db_sql_va/red/variables.tf
@@ -1,0 +1,11 @@
+variable "prefix" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/green/provider.tf
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/green/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/green/random.tf
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/green/random.tf
@@ -1,0 +1,11 @@
+resource "random_password" "this" {
+  length  = 17
+  special = true
+  number  = false
+}
+
+resource "random_string" "this" {
+  length  = 8
+  number  = false
+  special = false
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/green/resource_group.tf
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/green/resource_group.tf
@@ -1,0 +1,4 @@
+resource "azurerm_resource_group" "this" {
+  name     = "${var.prefix}-rg-green"
+  location = var.location
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/green/sql_server.tf
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/green/sql_server.tf
@@ -1,0 +1,28 @@
+resource "azurerm_mssql_server" "this" {
+  name                         = "${var.prefix}azuresqlserver-green"
+  resource_group_name          = azurerm_resource_group.this.name
+  location                     = azurerm_resource_group.this.location
+  version                      = "12.0"
+  administrator_login          = random_string.this.result
+  administrator_login_password = random_password.this.result
+
+  tags = var.tags
+}
+
+resource "azurerm_mssql_server_security_alert_policy" "this" {
+  resource_group_name = azurerm_resource_group.this.name
+  server_name         = azurerm_mssql_server.this.name
+  state               = "Enabled"
+}
+
+resource "azurerm_mssql_server_vulnerability_assessment" "this" {
+  server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.this.id
+  storage_container_path          = "${azurerm_storage_account.this.primary_blob_endpoint}${azurerm_storage_container.this.name}/"
+  storage_account_access_key      = azurerm_storage_account.this.primary_access_key
+
+  recurring_scans {
+    enabled = true
+    #email_subscription_admins = true
+    #emails                    = ["email@example1.com"]
+  }
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/green/storage_account.tf
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/green/storage_account.tf
@@ -1,0 +1,16 @@
+resource "azurerm_storage_account" "this" {
+  name                     = "${var.prefix}sagreen"
+  resource_group_name      = azurerm_resource_group.this.name
+  location                 = azurerm_resource_group.this.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = var.tags
+}
+
+resource "azurerm_storage_container" "this" {
+  name                  = "${var.prefix}scgreen"
+  storage_account_name  = azurerm_storage_account.this.name
+  container_access_type = "private"
+  depends_on            = [azurerm_mssql_server.this]
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/green/terraform.tfvars
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/green/terraform.tfvars
@@ -1,0 +1,8 @@
+prefix = "021"
+
+location = "eastus"
+
+tags = {
+  CustodianRule    = "ecc-azure-021-cis_db_sql_va_periodic_scan"
+  ComplianceStatus = "Green"
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/green/variables.tf
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/green/variables.tf
@@ -1,0 +1,11 @@
+variable "prefix" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/iam/ecc-azure-021-cis_db_sql_va_periodic_scan.json
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/iam/ecc-azure-021-cis_db_sql_va_periodic_scan.json
@@ -1,0 +1,20 @@
+{
+    "properties": {
+        "roleName": "Custodian-ecc-azure-021-cis_db_sql_va_periodic_scan",
+        "description": "",
+        "assignableScopes": [
+            "/subscriptions/{subscription_id}"
+        ],
+        "permissions": [
+            {
+                "actions": [
+                    "Microsoft.Sql/servers/read",
+                    "Microsoft.Sql/servers/vulnerabilityAssessments/read"
+                ],
+                "notActions": [],
+                "dataActions": [],
+                "notDataActions": []
+            }
+        ]
+    }
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/red/provider.tf
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/red/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/red/random.tf
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/red/random.tf
@@ -1,0 +1,11 @@
+resource "random_password" "this" {
+  length  = 17
+  special = true
+  number  = false
+}
+
+resource "random_string" "this" {
+  length  = 8
+  number  = false
+  special = false
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/red/resource_group.tf
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/red/resource_group.tf
@@ -1,0 +1,4 @@
+resource "azurerm_resource_group" "this" {
+  name     = "${var.prefix}-rg-red"
+  location = var.location
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/red/sql_server.tf
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/red/sql_server.tf
@@ -1,0 +1,28 @@
+resource "azurerm_mssql_server" "this" {
+  name                         = "${var.prefix}azuresqlserver-red"
+  resource_group_name          = azurerm_resource_group.this.name
+  location                     = azurerm_resource_group.this.location
+  version                      = "12.0"
+  administrator_login          = random_string.this.result
+  administrator_login_password = random_password.this.result
+
+  tags = var.tags
+}
+
+resource "azurerm_mssql_server_security_alert_policy" "this" {
+  resource_group_name = azurerm_resource_group.this.name
+  server_name         = azurerm_mssql_server.this.name
+  state               = "Enabled"
+}
+
+resource "azurerm_mssql_server_vulnerability_assessment" "this" {
+  server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.this.id
+  storage_container_path          = "${azurerm_storage_account.this.primary_blob_endpoint}${azurerm_storage_container.this.name}/"
+  storage_account_access_key      = azurerm_storage_account.this.primary_access_key
+
+  recurring_scans {
+    enabled = false
+    #email_subscription_admins = true
+    #emails                    = ["email@example1.com"]
+  }
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/red/storage_account.tf
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/red/storage_account.tf
@@ -1,0 +1,16 @@
+resource "azurerm_storage_account" "this" {
+  name                     = "${var.prefix}sared"
+  resource_group_name      = azurerm_resource_group.this.name
+  location                 = azurerm_resource_group.this.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = var.tags
+}
+
+resource "azurerm_storage_container" "this" {
+  name                  = "${var.prefix}scred"
+  storage_account_name  = azurerm_storage_account.this.name
+  container_access_type = "private"
+  depends_on            = [azurerm_mssql_server.this]
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/red/terraform.tfvars
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/red/terraform.tfvars
@@ -1,0 +1,8 @@
+prefix = "021"
+
+location = "eastus"
+
+tags = {
+  CustodianRule    = "ecc-azure-021-cis_db_sql_va_periodic_scan"
+  ComplianceStatus = "Red"
+}

--- a/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/red/variables.tf
+++ b/terraform/ecc-azure-021-cis_db_sql_va_periodic_scan/red/variables.tf
@@ -1,0 +1,11 @@
+variable "prefix" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/green/provider.tf
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/green/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/green/random.tf
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/green/random.tf
@@ -1,0 +1,11 @@
+resource "random_password" "this" {
+  length  = 17
+  special = true
+  number  = false
+}
+
+resource "random_string" "this" {
+  length  = 8
+  number  = false
+  special = false
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/green/resource_group.tf
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/green/resource_group.tf
@@ -1,0 +1,4 @@
+resource "azurerm_resource_group" "this" {
+  name     = "${var.prefix}-rg-green"
+  location = var.location
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/green/sql_server.tf
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/green/sql_server.tf
@@ -1,0 +1,28 @@
+resource "azurerm_mssql_server" "this" {
+  name                         = "${var.prefix}azuresqlserver-green"
+  resource_group_name          = azurerm_resource_group.this.name
+  location                     = azurerm_resource_group.this.location
+  version                      = "12.0"
+  administrator_login          = random_string.this.result
+  administrator_login_password = random_password.this.result
+
+  tags = var.tags
+}
+
+resource "azurerm_mssql_server_security_alert_policy" "this" {
+  resource_group_name = azurerm_resource_group.this.name
+  server_name         = azurerm_mssql_server.this.name
+  state               = "Enabled"
+}
+
+resource "azurerm_mssql_server_vulnerability_assessment" "this" {
+  server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.this.id
+  storage_container_path          = "${azurerm_storage_account.this.primary_blob_endpoint}${azurerm_storage_container.this.name}/"
+  storage_account_access_key      = azurerm_storage_account.this.primary_access_key
+
+  recurring_scans {
+    #enabled = true
+    #email_subscription_admins = true
+    emails = ["email@example1.com"]
+  }
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/green/storage_account.tf
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/green/storage_account.tf
@@ -1,0 +1,16 @@
+resource "azurerm_storage_account" "this" {
+  name                     = "${var.prefix}sagreen"
+  resource_group_name      = azurerm_resource_group.this.name
+  location                 = azurerm_resource_group.this.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = var.tags
+}
+
+resource "azurerm_storage_container" "this" {
+  name                  = "${var.prefix}scgreen"
+  storage_account_name  = azurerm_storage_account.this.name
+  container_access_type = "private"
+  depends_on            = [azurerm_mssql_server.this]
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/green/terraform.tfvars
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/green/terraform.tfvars
@@ -1,0 +1,8 @@
+prefix = "022"
+
+location = "eastus"
+
+tags = {
+  CustodianRule    = "ecc-azure-022-cis_db_sql_va_send_scan_report"
+  ComplianceStatus = "Green"
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/green/variables.tf
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/green/variables.tf
@@ -1,0 +1,11 @@
+variable "prefix" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/iam/ecc-azure-022-cis_db_sql_va_send_scan_report.json
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/iam/ecc-azure-022-cis_db_sql_va_send_scan_report.json
@@ -1,0 +1,20 @@
+{
+    "properties": {
+        "roleName": "Custodian-ecc-azure-022-cis_db_sql_va_send_scan_report",
+        "description": "",
+        "assignableScopes": [
+            "/subscriptions/{subscription_id}"
+        ],
+        "permissions": [
+            {
+                "actions": [
+                    "Microsoft.Sql/servers/read",
+                    "Microsoft.Sql/servers/vulnerabilityAssessments/read"
+                ],
+                "notActions": [],
+                "dataActions": [],
+                "notDataActions": []
+            }
+        ]
+    }
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/red/provider.tf
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/red/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/red/random.tf
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/red/random.tf
@@ -1,0 +1,11 @@
+resource "random_password" "this" {
+  length  = 13
+  special = true
+  number  = false
+}
+
+resource "random_string" "this" {
+  length  = 8
+  number  = false
+  special = false
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/red/resource_group.tf
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/red/resource_group.tf
@@ -1,0 +1,4 @@
+resource "azurerm_resource_group" "this" {
+  name     = "${var.prefix}-rg-red"
+  location = var.location
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/red/sql_server.tf
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/red/sql_server.tf
@@ -1,0 +1,28 @@
+resource "azurerm_mssql_server" "this" {
+  name                         = "${var.prefix}azuresqlserver-red"
+  resource_group_name          = azurerm_resource_group.this.name
+  location                     = azurerm_resource_group.this.location
+  version                      = "12.0"
+  administrator_login          = random_string.this.result
+  administrator_login_password = random_password.this.result
+
+  tags = var.tags
+}
+
+resource "azurerm_mssql_server_security_alert_policy" "this" {
+  resource_group_name = azurerm_resource_group.this.name
+  server_name         = azurerm_mssql_server.this.name
+  state               = "Enabled"
+}
+
+resource "azurerm_mssql_server_vulnerability_assessment" "this" {
+  server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.this.id
+  storage_container_path          = "${azurerm_storage_account.this.primary_blob_endpoint}${azurerm_storage_container.this.name}/"
+  storage_account_access_key      = azurerm_storage_account.this.primary_access_key
+
+  recurring_scans {
+    #enabled = false
+    #email_subscription_admins = false
+    emails = []
+  }
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/red/storage_account.tf
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/red/storage_account.tf
@@ -1,0 +1,16 @@
+resource "azurerm_storage_account" "this" {
+  name                     = "${var.prefix}sared"
+  resource_group_name      = azurerm_resource_group.this.name
+  location                 = azurerm_resource_group.this.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = var.tags
+}
+
+resource "azurerm_storage_container" "this" {
+  name                  = "${var.prefix}scred"
+  storage_account_name  = azurerm_storage_account.this.name
+  container_access_type = "private"
+  depends_on            = [azurerm_mssql_server.this]
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/red/terraform.tfvars
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/red/terraform.tfvars
@@ -1,0 +1,8 @@
+prefix = "022"
+
+location = "eastus"
+
+tags = {
+  CustodianRule    = "ecc-azure-022-cis_db_sql_va_send_scan_report"
+  ComplianceStatus = "Red"
+}

--- a/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/red/variables.tf
+++ b/terraform/ecc-azure-022-cis_db_sql_va_send_scan_report/red/variables.tf
@@ -1,0 +1,11 @@
+variable "prefix" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/green/provider.tf
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/green/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/green/random.tf
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/green/random.tf
@@ -1,0 +1,11 @@
+resource "random_password" "this" {
+  length  = 17
+  special = true
+  number  = false
+}
+
+resource "random_string" "this" {
+  length  = 8
+  number  = false
+  special = false
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/green/resource_group.tf
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/green/resource_group.tf
@@ -1,0 +1,4 @@
+resource "azurerm_resource_group" "this" {
+  name     = "${var.prefix}-rg-green"
+  location = var.location
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/green/sql_server.tf
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/green/sql_server.tf
@@ -1,0 +1,28 @@
+resource "azurerm_mssql_server" "this" {
+  name                         = "${var.prefix}azuresqlserver-green"
+  resource_group_name          = azurerm_resource_group.this.name
+  location                     = azurerm_resource_group.this.location
+  version                      = "12.0"
+  administrator_login          = random_string.this.result
+  administrator_login_password = random_password.this.result
+
+  tags = var.tags
+}
+
+resource "azurerm_mssql_server_security_alert_policy" "this" {
+  resource_group_name = azurerm_resource_group.this.name
+  server_name         = azurerm_mssql_server.this.name
+  state               = "Enabled"
+}
+
+resource "azurerm_mssql_server_vulnerability_assessment" "this" {
+  server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.this.id
+  storage_container_path          = "${azurerm_storage_account.this.primary_blob_endpoint}${azurerm_storage_container.this.name}/"
+  storage_account_access_key      = azurerm_storage_account.this.primary_access_key
+
+  recurring_scans {
+    #enabled = true
+    email_subscription_admins = true
+    #emails = ["email@example1.com"]
+  }
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/green/storage_account.tf
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/green/storage_account.tf
@@ -1,0 +1,16 @@
+resource "azurerm_storage_account" "this" {
+  name                     = "${var.prefix}sagreen"
+  resource_group_name      = azurerm_resource_group.this.name
+  location                 = azurerm_resource_group.this.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = var.tags
+}
+
+resource "azurerm_storage_container" "this" {
+  name                  = "${var.prefix}scgreen"
+  storage_account_name  = azurerm_storage_account.this.name
+  container_access_type = "private"
+  depends_on            = [azurerm_mssql_server.this]
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/green/terraform.tfvars
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/green/terraform.tfvars
@@ -1,0 +1,8 @@
+prefix = "023"
+
+location = "eastus"
+
+tags = {
+  CustodianRule    = "ecc-azure-023-cis_db_sql_va_email_notifications"
+  ComplianceStatus = "Green"
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/green/variables.tf
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/green/variables.tf
@@ -1,0 +1,11 @@
+variable "prefix" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/iam/ecc-azure-023-cis_db_sql_va_email_notifications.json
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/iam/ecc-azure-023-cis_db_sql_va_email_notifications.json
@@ -1,0 +1,20 @@
+{
+    "properties": {
+        "roleName": "Custodian-ecc-azure-023-cis_db_sql_va_email_notifications",
+        "description": "",
+        "assignableScopes": [
+            "/subscriptions/{subscription_id}"
+        ],
+        "permissions": [
+            {
+                "actions": [
+                    "Microsoft.Sql/servers/read",
+                    "Microsoft.Sql/servers/vulnerabilityAssessments/read"
+                ],
+                "notActions": [],
+                "dataActions": [],
+                "notDataActions": []
+            }
+        ]
+    }
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/red/provider.tf
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/red/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/red/random.tf
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/red/random.tf
@@ -1,0 +1,11 @@
+resource "random_password" "this" {
+  length  = 13
+  special = true
+  number  = false
+}
+
+resource "random_string" "this" {
+  length  = 8
+  number  = false
+  special = false
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/red/resource_group.tf
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/red/resource_group.tf
@@ -1,0 +1,4 @@
+resource "azurerm_resource_group" "this" {
+  name     = "${var.prefix}-rg-red"
+  location = var.location
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/red/sql_server.tf
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/red/sql_server.tf
@@ -1,0 +1,28 @@
+resource "azurerm_mssql_server" "this" {
+  name                         = "${var.prefix}azuresqlserver-red"
+  resource_group_name          = azurerm_resource_group.this.name
+  location                     = azurerm_resource_group.this.location
+  version                      = "12.0"
+  administrator_login          = random_string.this.result
+  administrator_login_password = random_password.this.result
+
+  tags = var.tags
+}
+
+resource "azurerm_mssql_server_security_alert_policy" "this" {
+  resource_group_name = azurerm_resource_group.this.name
+  server_name         = azurerm_mssql_server.this.name
+  state               = "Enabled"
+}
+
+resource "azurerm_mssql_server_vulnerability_assessment" "this" {
+  server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.this.id
+  storage_container_path          = "${azurerm_storage_account.this.primary_blob_endpoint}${azurerm_storage_container.this.name}/"
+  storage_account_access_key      = azurerm_storage_account.this.primary_access_key
+
+  recurring_scans {
+    #enabled = false
+    email_subscription_admins = false
+    #emails = []
+  }
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/red/storage_account.tf
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/red/storage_account.tf
@@ -1,0 +1,16 @@
+resource "azurerm_storage_account" "this" {
+  name                     = "${var.prefix}sared"
+  resource_group_name      = azurerm_resource_group.this.name
+  location                 = azurerm_resource_group.this.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = var.tags
+}
+
+resource "azurerm_storage_container" "this" {
+  name                  = "${var.prefix}scred"
+  storage_account_name  = azurerm_storage_account.this.name
+  container_access_type = "private"
+  depends_on            = [azurerm_mssql_server.this]
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/red/terraform.tfvars
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/red/terraform.tfvars
@@ -1,0 +1,8 @@
+prefix = "023"
+
+location = "eastus"
+
+tags = {
+  CustodianRule    = "ecc-azure-023-cis_db_sql_va_email_notifications"
+  ComplianceStatus = "Red"
+}

--- a/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/red/variables.tf
+++ b/terraform/ecc-azure-023-cis_db_sql_va_email_notifications/red/variables.tf
@@ -1,0 +1,11 @@
+variable "prefix" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}


### PR DESCRIPTION
The rules is deprecated in CIS Microsoft Azure Foundations Benchmark v2.1.0. 
We cannot evaluate the parameters because of VA Express Configuration. Now VA enables automatically with Defender for SQL. 
016, 005, 007 covers the deprecated rules.